### PR TITLE
add --validate-args option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Build ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE_PORTABLE}}
       run: msbuild /p:Configuration="${{env.CONFIGURATION_RELEASE_PORTABLE}}" ${{env.PROJECT}}.sln
 
-    - name: Build ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}}
-      run: msbuild /p:Configuration="${{env.CONFIGURATION_RELEASE}}" ${{env.PROJECT}}.sln
+    #- name: Build ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}}
+    #  run: msbuild /p:Configuration="${{env.CONFIGURATION_RELEASE}}" ${{env.PROJECT}}.sln
 
     # Test
 
@@ -44,13 +44,13 @@ jobs:
 
     # Upload artifacts
 
-    - name: Publish ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}} Installer
-      uses: actions/upload-artifact@v4.3.0
-      with:
-        name: ${{env.PROJECT}}Installer
-        path: |
-          ${{env.PROJECT}}.Bundle/bin/${{env.CONFIGURATION_RELEASE}}/${{env.PROJECT}}Installer.exe
-        retention-days: ${{env.RETENTION_DAYS}}
+    #- name: Publish ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}} Installer
+    #  uses: actions/upload-artifact@v4.3.0
+    #  with:
+    #    name: ${{env.PROJECT}}Installer
+    #    path: |
+    #      ${{env.PROJECT}}.Bundle/bin/${{env.CONFIGURATION_RELEASE}}/${{env.PROJECT}}Installer.exe
+    #    retention-days: ${{env.RETENTION_DAYS}}
 
     - name: Publish ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE_PORTABLE}}
       uses: actions/upload-artifact@v4.3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Build ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE_PORTABLE}}
       run: msbuild /p:Configuration="${{env.CONFIGURATION_RELEASE_PORTABLE}}" ${{env.PROJECT}}.sln
 
-    #- name: Build ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}}
-    #  run: msbuild /p:Configuration="${{env.CONFIGURATION_RELEASE}}" ${{env.PROJECT}}.sln
+    - name: Build ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}}
+      run: msbuild /p:Configuration="${{env.CONFIGURATION_RELEASE}}" ${{env.PROJECT}}.sln
 
     # Test
 
@@ -44,13 +44,13 @@ jobs:
 
     # Upload artifacts
 
-    #- name: Publish ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}} Installer
-    #  uses: actions/upload-artifact@v4.3.0
-    #  with:
-    #    name: ${{env.PROJECT}}Installer
-    #    path: |
-    #      ${{env.PROJECT}}.Bundle/bin/${{env.CONFIGURATION_RELEASE}}/${{env.PROJECT}}Installer.exe
-    #    retention-days: ${{env.RETENTION_DAYS}}
+    - name: Publish ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE}} Installer
+      uses: actions/upload-artifact@v4.3.0
+      with:
+        name: ${{env.PROJECT}}Installer
+        path: |
+          ${{env.PROJECT}}.Bundle/bin/${{env.CONFIGURATION_RELEASE}}/${{env.PROJECT}}Installer.exe
+        retention-days: ${{env.RETENTION_DAYS}}
 
     - name: Publish ${{env.PROJECT}} ${{env.CONFIGURATION_RELEASE_PORTABLE}}
       uses: actions/upload-artifact@v4.3.0

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -72,6 +72,7 @@ public sealed class AppEntry : WindowsFormsApplicationBase
             IEnumerable<TimerStart?> timerStarts = arguments.TimerStart;
             foreach (TimerStart? timerStart in timerStarts)
             {
+                Console.WriteLine();
                 Console.Write(timerStart.ToString());
             }
             return false;

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -241,7 +241,7 @@ public sealed class AppEntry : WindowsFormsApplicationBase
             int index = arguments.TimerStart.OfType<TimerStart>().Count();
             foreach (var timerStart in arguments.TimerStart.OfType<TimerStart>())
             {
-                Console.Write(timerStart.ToString() + index > 1 ? Environment.NewLine : "");
+                Console.Write(timerStart.ToString() + (index > 1 ? Environment.NewLine : ""));
                 index = index - 1;
             }
         }

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -66,19 +66,9 @@ public sealed class AppEntry : WindowsFormsApplicationBase
         AppManager.Instance.Initialize();
 
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
-        if (arguments.ValidateArgs && !arguments.HasParseError)
+
+        if (ValidateArgsToStdout())
         {
-            Console.WriteLine("true");
-            IEnumerable<TimerStart?> timerStarts = arguments.TimerStart;
-            foreach (TimerStart? timerStart in timerStarts)
-            {
-                Console.WriteLine();
-                Console.Write(timerStart.ToString());
-            }
-            return false;
-        } else if (arguments.ValidateArgs && arguments.HasParseError)
-        {
-            Console.Write("false");
             return false;
         }
         
@@ -107,16 +97,12 @@ public sealed class AppEntry : WindowsFormsApplicationBase
     protected override void OnStartupNextInstance(StartupNextInstanceEventArgs eventArgs)
     {
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
-        if (arguments.ValidateArgs && !arguments.HasParseError)
+
+        if (ValidateArgsToStdout())
         {
-            Console.WriteLine("true");
-            return;
-        } else if (arguments.ValidateArgs && arguments.HasParseError)
-        {
-            Console.WriteLine("false");
             return;
         }
-        
+                
         if (arguments.ShouldShowUsage || arguments.HasParseError)
         {
             CommandLineArguments.ShowUsage(arguments.ParseErrorMessage);
@@ -232,5 +218,32 @@ public sealed class AppEntry : WindowsFormsApplicationBase
     {
         AppManager.Instance.Persist();
         AppManager.Instance.Dispose();
+    }
+
+    /// <summary>
+    /// Outputs false or true with parsed times if the --validate-args option is on.
+    /// </summary>
+    /// <param name="arguments">Parsed command-line arguments.</param>
+    /// <returns>A value indicating whether the --validate-args option was parsed.</returns>
+    private static bool ValidateArgsToStdout(CommandLineArguments arguments)
+    {
+        if (!arguments.ValidateArgs)
+        {
+            return false;
+        }
+
+        var hasParseError = arguments.HasParseError;
+
+        Console.WriteLine(hasParseError ? "false" : "true");
+
+        if (!hasParseError)
+        {
+            foreach (var timerStart in arguments.TimerStart.OfType<TimerStart>())
+            {
+                Console.WriteLine(timerStart.ToString());
+            }
+        }
+
+        return true;
     }
 }

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -68,11 +68,11 @@ public sealed class AppEntry : WindowsFormsApplicationBase
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
         if (arguments.ValidateArgs && !arguments.HasParseError)
         {
-            Console.WriteLine("true");
+            Console.Write("true");
             return false;
         } else if (arguments.ValidateArgs && arguments.HasParseError)
         {
-            Console.WriteLine("false");
+            Console.Write("false");
             return false;
         }
         

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -238,9 +238,11 @@ public sealed class AppEntry : WindowsFormsApplicationBase
 
         if (!hasParseError)
         {
+            int index = arguments.TimerStart.OfType<TimerStart>().Count();
             foreach (var timerStart in arguments.TimerStart.OfType<TimerStart>())
             {
-                Console.WriteLine(timerStart.ToString());
+                Console.Write(timerStart.ToString() + index > 1 ? Environment.NewLine : "");
+                index = index - 1;
             }
         }
 

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -68,7 +68,12 @@ public sealed class AppEntry : WindowsFormsApplicationBase
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
         if (arguments.ValidateArgs && !arguments.HasParseError)
         {
-            Console.Write("true");
+            Console.WriteLine("true");
+            IEnumerable<TimerStart?> timerStarts = arguments.TimerStart;
+            foreach (TimerStart? timerStart in timerStarts)
+            {
+                Console.Write(timerStart.ToString());
+            }
             return false;
         } else if (arguments.ValidateArgs && arguments.HasParseError)
         {

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -67,7 +67,7 @@ public sealed class AppEntry : WindowsFormsApplicationBase
 
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
 
-        if (ValidateArgsToStdout())
+        if (ValidateArgsToStdout(arguments))
         {
             return false;
         }
@@ -98,7 +98,7 @@ public sealed class AppEntry : WindowsFormsApplicationBase
     {
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
 
-        if (ValidateArgsToStdout())
+        if (ValidateArgsToStdout(arguments))
         {
             return;
         }

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -66,6 +66,16 @@ public sealed class AppEntry : WindowsFormsApplicationBase
         AppManager.Instance.Initialize();
 
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
+        if (arguments.ValidateArgs && !arguments.HasParseError)
+        {
+            Console.WriteLine("true");
+            return false;
+        } else if (arguments.ValidateArgs && arguments.HasParseError)
+        {
+            Console.WriteLine("false");
+            return false;
+        }
+        
         if (arguments.ShouldShowUsage || arguments.HasParseError)
         {
             CommandLineArguments.ShowUsage(arguments.ParseErrorMessage);
@@ -91,6 +101,16 @@ public sealed class AppEntry : WindowsFormsApplicationBase
     protected override void OnStartupNextInstance(StartupNextInstanceEventArgs eventArgs)
     {
         CommandLineArguments arguments = CommandLineArguments.Parse(eventArgs.CommandLine);
+        if (arguments.ValidateArgs && !arguments.HasParseError)
+        {
+            Console.WriteLine("true");
+            return;
+        } else if (arguments.ValidateArgs && arguments.HasParseError)
+        {
+            Console.WriteLine("false");
+            return;
+        }
+        
         if (arguments.ShouldShowUsage || arguments.HasParseError)
         {
             CommandLineArguments.ShowUsage(arguments.ParseErrorMessage);

--- a/Hourglass/CommandLineArguments.cs
+++ b/Hourglass/CommandLineArguments.cs
@@ -268,7 +268,8 @@ public sealed class CommandLineArguments
             LoopSound = LoopSound,
             WindowTitleMode = WindowTitleMode,
             WindowSize = GetWindowSize(),
-            LockInterface = LockInterface
+            LockInterface = LockInterface,
+            ValidateArgs = ValidateArgs
         };
     }
 

--- a/Hourglass/CommandLineArguments.cs
+++ b/Hourglass/CommandLineArguments.cs
@@ -226,10 +226,12 @@ public sealed class CommandLineArguments
         }
         catch (ParseException e)
         {
+            bool validateCmdArgs = GetValidateCommandLineArguments(args);
             return new()
             {
                 HasParseError = true,
-                ParseErrorMessage = e.Message
+                ParseErrorMessage = e.Message,
+                ValidateArgs = validateCmdArgs
             };
         }
     }
@@ -821,6 +823,36 @@ public sealed class CommandLineArguments
         }
 
         return useFactoryDefaults ? argumentsBasedOnFactoryDefaults : argumentsBasedOnMostRecentOptions;
+    }
+
+    /// <summary>
+    /// Parses command-line arguments to check for "--validate-args on" only.
+    /// </summary>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>Boolean that indicates if "--validate-args on" was parsed</returns>
+    private static bool GetValidateCommandLineArguments(IEnumerable<string> args)
+    {
+        bool validateArgs = false;
+        Queue<string> remainingArgs = new(args);
+        while (remainingArgs.Count > 0)
+        {
+            string arg = remainingArgs.Dequeue();
+
+            switch (arg)
+            {
+                case "--validate-args":                    
+                    validateArgs = GetBoolValue(
+                        arg,
+                        remainingArgs);
+                    return validateArgs;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        return validateArgs;
     }
 
     /// <summary>

--- a/Hourglass/CommandLineArguments.cs
+++ b/Hourglass/CommandLineArguments.cs
@@ -204,6 +204,11 @@ public sealed class CommandLineArguments
     /// </summary>
     public bool ResumeAll { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether to print to console if the parsed args are valid.
+    /// </summary>
+    public bool ValidateArgs { get; private set; }
+
     #endregion
 
     #region Public Methods
@@ -319,7 +324,8 @@ public sealed class CommandLineArguments
             WindowState = windowSize.WindowState != WindowState.Minimized ? windowSize.WindowState : windowSize.RestoreWindowState,
             RestoreWindowState = windowSize.RestoreWindowState,
             WindowBounds = windowSize.RestoreBounds,
-            LockInterface = options.LockInterface
+            LockInterface = options.LockInterface,
+            ValidateArgs = options.ValidateArgs
         };
     }
 
@@ -361,7 +367,8 @@ public sealed class CommandLineArguments
             WindowState = defaultOptions.WindowSize?.WindowState ?? WindowState.Normal,
             RestoreWindowState = defaultOptions.WindowSize?.RestoreWindowState ?? WindowState.Normal,
             WindowBounds = defaultWindowBoundsWithLocation,
-            LockInterface = defaultOptions.LockInterface
+            LockInterface = defaultOptions.LockInterface,
+            ValidateArgs = defaultOptions.ValidateArgs
         };
     }
 
@@ -758,6 +765,17 @@ public sealed class CommandLineArguments
 
                     argumentsBasedOnMostRecentOptions.LockInterface = lockInterface;
                     argumentsBasedOnFactoryDefaults.LockInterface = lockInterface;
+                    break;
+
+                case "--validate-args":
+                    ThrowIfDuplicateSwitch(specifiedSwitches, "--validate-args");
+                    
+                    bool validateArgs = GetBoolValue(
+                        arg,
+                        remainingArgs);
+
+                    argumentsBasedOnMostRecentOptions.ValidateArgs = validateArgs;
+                    argumentsBasedOnFactoryDefaults.ValidateArgs = validateArgs;
                     break;
 
                 case "--use-factory-defaults":

--- a/Hourglass/CommandLineArguments.cs
+++ b/Hourglass/CommandLineArguments.cs
@@ -226,7 +226,16 @@ public sealed class CommandLineArguments
         }
         catch (ParseException e)
         {
-            bool validateCmdArgs = GetValidateCommandLineArguments(args);
+            bool validateCmdArgs = false;
+            try
+            {
+                validateCmdArgs = GetValidateCommandLineArguments(args);
+            }
+            catch (ParseException eValidate)
+            {
+                e = eValidate;
+            }
+            
             return new()
             {
                 HasParseError = true,
@@ -832,27 +841,17 @@ public sealed class CommandLineArguments
     /// <returns>Boolean that indicates if "--validate-args on" was parsed</returns>
     private static bool GetValidateCommandLineArguments(IEnumerable<string> args)
     {
-        bool validateArgs = false;
         Queue<string> remainingArgs = new(args);
         while (remainingArgs.Count > 0)
         {
             string arg = remainingArgs.Dequeue();
 
-            switch (arg)
+            if (arg == "--validate-args")
             {
-                case "--validate-args":                    
-                    validateArgs = GetBoolValue(
-                        arg,
-                        remainingArgs);
-                    return validateArgs;
-                    break;
-
-                default:
-                    break;
+                return GetBoolValue(arg, remainingArgs);
             }
         }
-
-        return validateArgs;
+        return false;
     }
 
     /// <summary>

--- a/Hourglass/Managers/TimerOptionsManager.cs
+++ b/Hourglass/Managers/TimerOptionsManager.cs
@@ -88,5 +88,8 @@ public sealed class TimerOptionsManager : Manager
         // Never save shutting down when expired or lock interface options
         _mostRecentOptions.ShutDownWhenExpired = false;
         _mostRecentOptions.LockInterface = false;
+
+        // Never save validating args
+        _mostRecentOptions.ValidateArgs = false;
     }
 }

--- a/Hourglass/Resources/Usage.txt
+++ b/Hourglass/Resources/Usage.txt
@@ -287,7 +287,7 @@ Options:
         Default value   off
         Alias           -z, /z
 
-  --validate-args
+  --validate-args on|off
         Checks if the provided arguments are valid and prints "true" or "false"
         to the command line without actually starting the timer.
 
@@ -324,6 +324,7 @@ Options:
             --window-state                -w  normal
             --window-bounds               -b  auto,auto,355,160
             --lock-interface              -z  off
+            --validate-args                   off
 
         Required        no
         Alias           -d, /d

--- a/Hourglass/Resources/Usage.txt
+++ b/Hourglass/Resources/Usage.txt
@@ -291,6 +291,12 @@ Options:
         Checks if the provided arguments are valid and prints "true" or "false"
         to the command line without actually starting the timer.
 
+        IMPORTANT: Since this is an option that provides a command line output 
+        but Hourglass is a UI only application, it needs to be called with 
+        "| MORE" like:
+
+        Hourglass.exe --validate-args on [OPTIONS] [<input>] | MORE
+
         Required        no
 
   --use-factory-defaults

--- a/Hourglass/Resources/Usage.txt
+++ b/Hourglass/Resources/Usage.txt
@@ -288,8 +288,9 @@ Options:
         Alias           -z, /z
 
   --validate-args on|off
-        Checks if the provided arguments are valid and prints "true" or "false"
-        to stdout without actually starting the timer.
+        Checks if the provided arguments are valid and outputs "true" or "false"
+        to stdout without actually starting the timer. If time input/s is/are 
+        provided, the parsed time/s are written as well.
 
         IMPORTANT: Since this is an option that provides a stdout output 
         but Hourglass is a UI only application, it needs to be called with 

--- a/Hourglass/Resources/Usage.txt
+++ b/Hourglass/Resources/Usage.txt
@@ -289,15 +289,20 @@ Options:
 
   --validate-args on|off
         Checks if the provided arguments are valid and prints "true" or "false"
-        to the command line without actually starting the timer.
+        to stdout without actually starting the timer.
 
-        IMPORTANT: Since this is an option that provides a command line output 
+        IMPORTANT: Since this is an option that provides a stdout output 
         but Hourglass is a UI only application, it needs to be called with 
-        "| MORE" like:
+        "| MORE"  if called directly on the command line like:
 
         Hourglass.exe --validate-args on [OPTIONS] [<input>] | MORE
 
+        Calls from languages like Python with subprocess.run() or nodeJS with 
+        child_process.exec() may capture stdout by default and don't need 
+        "| MORE".
+
         Required        no
+        Default value   off
 
   --use-factory-defaults
         If specified, any options that are not explicitly set with another

--- a/Hourglass/Resources/Usage.txt
+++ b/Hourglass/Resources/Usage.txt
@@ -287,6 +287,12 @@ Options:
         Default value   off
         Alias           -z, /z
 
+  --validate-args
+        Checks if the provided arguments are valid and prints "true" or "false"
+        to the command line without actually starting the timer.
+
+        Required        no
+
   --use-factory-defaults
         If specified, any options that are not explicitly set with another
         switch are set to their factory default setting rather than the last

--- a/Hourglass/Serialization/TimerOptionsInfo.cs
+++ b/Hourglass/Serialization/TimerOptionsInfo.cs
@@ -109,6 +109,11 @@ public sealed class TimerOptionsInfo
     public bool LockInterface { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to print to console if the parsed args are valid.
+    /// </summary>
+    public bool ValidateArgs { get; set; }
+
+    /// <summary>
     /// Returns a <see cref="TimerOptionsInfo"/> for the specified <see cref="TimerOptions"/>.
     /// </summary>
     /// <param name="options">A <see cref="TimerOptions"/>.</param>

--- a/Hourglass/Timing/TimerOptions.cs
+++ b/Hourglass/Timing/TimerOptions.cs
@@ -165,6 +165,11 @@ public sealed class TimerOptions : INotifyPropertyChanged
     /// </summary>
     private bool _digitalClockTime;
 
+    /// <summary>
+    /// A value indicating whether to print to console if the parsed args are valid.
+    /// </summary>
+    private bool _validateArgs;
+
     #endregion
 
     #region Constructors
@@ -196,6 +201,7 @@ public sealed class TimerOptions : INotifyPropertyChanged
             WindowState.Normal,
             false /* isFullScreen */);
         _lockInterface = false;
+        _validateArgs = false;
     }
 
     /// <summary>
@@ -572,6 +578,25 @@ public sealed class TimerOptions : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to print to console if the parsed args are valid.
+    /// </summary>
+    public bool ValidateArgs
+    {
+        get => _validateArgs;
+
+        set
+        {
+            if (_validateArgs == value)
+            {
+                return;
+            }
+
+            _validateArgs = value;
+            PropertyChanged.Notify(this);
+        }
+    }
+
     #endregion
 
     #region Public Methods
@@ -630,6 +655,7 @@ public sealed class TimerOptions : INotifyPropertyChanged
         _windowTitleMode = options._windowTitleMode;
         _windowSize = WindowSize.FromWindowSize(options.WindowSize);
         _lockInterface = options._lockInterface;
+        _validateArgs = options._validateArgs;
 
         PropertyChanged.Notify(this,
             nameof(WindowTitleMode),
@@ -649,7 +675,8 @@ public sealed class TimerOptions : INotifyPropertyChanged
             nameof(Theme),
             nameof(Sound),
             nameof(LoopSound),
-            nameof(LockInterface));
+            nameof(LockInterface),
+            nameof(ValidateArgs));
     }
 
     /// <summary>
@@ -682,6 +709,7 @@ public sealed class TimerOptions : INotifyPropertyChanged
         _windowTitleMode = info.WindowTitleMode;
         _windowSize = WindowSize.FromWindowSizeInfo(info.WindowSize);
         _lockInterface = info.LockInterface;
+        _validateArgs = info.ValidateArgs;
 
         PropertyChanged.Notify(this,
             nameof(WindowTitleMode),
@@ -701,7 +729,8 @@ public sealed class TimerOptions : INotifyPropertyChanged
             nameof(Theme),
             nameof(Sound),
             nameof(LoopSound),
-            nameof(LockInterface));
+            nameof(LockInterface),
+            nameof(ValidateArgs));
     }
 
     /// <summary>
@@ -729,7 +758,8 @@ public sealed class TimerOptions : INotifyPropertyChanged
             LoopSound = _loopSound,
             WindowTitleMode = _windowTitleMode,
             WindowSize = WindowSizeInfo.FromWindowSize(_windowSize)!,
-            LockInterface = _lockInterface
+            LockInterface = _lockInterface,
+            ValidateArgs = _validateArgs
         };
     }
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Run `hourglass -h` to display the **Hourglass** [command-line reference](https:/
 - New option `--digital-clock-time` / `-c`
 - New option `--multi-timers` / `-mt`
 - New option `--activate-next` / `-an`
+- New option `--validate-args`
 
 See [usage](https://github.com/i2van/hourglass/blob/develop/Hourglass/Resources/Usage.txt) for details.
 


### PR DESCRIPTION
Hi,
I added a new option called `--validate-args on/off` that checks if the provided CLI arguments are valid. If they are, it outputs the word `true` as well as the parsed `TimerStart.ToString()` value/s to stdout. If the arguments produce an error, `false` gets send to stdout. I also added the appropriate usage to the help dialog.

To test this in the command line (e.g. cmd.exe) you also need to add `|MORE` after the function call (e.g. `hourglass.exe --validate-args on --title test until 3pm |MORE`, because WinForms UI apps don't print their stdout to the console by default. If hourglass.exe is called via e.g. nodeJS with execFile() (for my use case), this is not necessary since it captures stdout by default. I use this for a [plugin](https://github.com/pivotiiii/flow_launcher_timer) for [Flow Launcher](https://github.com/Flow-Launcher/Flow.Launcher) that sets a timer but needs to check if the supplied input is actually valid before presenting any options.

The portable build of hourglass builds with my changes, but the installer version throws an error about the installer program having duplicate symbols. This also happens on the develop branch without any changes. Feel free to ignore the updated workflow file.

I have not updated any of the version info files or anything else, just what was necessary to make this option work.