### PR TITLE
feat: add tray-only taskbar option

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -254,6 +254,8 @@ To exit full-screen mode, press `Alt`+`Enter` or `F11` again; `Double Click` on 
 
 To remove the **Hourglass** icon from the notification area and restore any hidden timer windows, `Right Click` on any empty space in the timer window and uncheck **Show in notification area**.
 
+To also hide the timer window from the taskbar while it is shown in the notification area, `Right Click` on any empty space in the timer window and check **Hide from taskbar if shown in notification area**. The command-line option is [`--hide-from-taskbar-when-in-notification-area`](https://github.com/search?type=code&q=repo%3Ai2van%2Fhourglass+path%3AHourglass%2FResources%2FUsage.txt+--hide-from-taskbar-when-in-notification-area), `-hf`, `/hf`.
+
 ## What are the timer window keyboard shortcuts?
 
 | Shortcut                  | Action                                                     |

--- a/Hourglass/App.config
+++ b/Hourglass/App.config
@@ -16,6 +16,9 @@
             <setting name="ShowInNotificationArea" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="HideFromTaskbarWhenInNotificationArea" serializeAs="String">
+                <value>False</value>
+            </setting>
             <setting name="UniqueId" serializeAs="String">
                 <value>00000000-0000-0000-0000-000000000000</value>
             </setting>

--- a/Hourglass/AppEntry.cs
+++ b/Hourglass/AppEntry.cs
@@ -219,6 +219,7 @@ public sealed class AppEntry : WindowsFormsApplicationBase
     private static void SetGlobalSettingsFromArguments(CommandLineArguments arguments)
     {
         Settings.Default.ShowInNotificationArea = arguments.ShowInNotificationArea;
+        Settings.Default.HideFromTaskbarWhenInNotificationArea = arguments.HideFromTaskbarWhenInNotificationArea;
         Settings.Default.OpenSavedTimersOnStartup = arguments.OpenSavedTimers;
         Settings.Default.SaveTimerOnClosing = arguments.SaveTimerOnClosing;
         Settings.Default.Prefer24HourTime = arguments.Prefer24HourTime;

--- a/Hourglass/CommandLineArguments.cs
+++ b/Hourglass/CommandLineArguments.cs
@@ -102,6 +102,12 @@ public sealed class CommandLineArguments
     public bool ShowInNotificationArea { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether the timer window should be hidden from the taskbar when it is shown in the
+    /// notification area.
+    /// </summary>
+    public bool HideFromTaskbarWhenInNotificationArea { get; private set; }
+
+    /// <summary>
     /// Gets a value indicating whether to reverse the progress bar (count backwards).
     /// </summary>
     public bool ReverseProgressBar { get; private set; }
@@ -440,6 +446,7 @@ public sealed class CommandLineArguments
             ShowTimeElapsed = options.ShowTimeElapsed,
             ShowTriggerTime = options.ShowTriggerTime,
             ShowInNotificationArea = Settings.Default.ShowInNotificationArea,
+            HideFromTaskbarWhenInNotificationArea = Settings.Default.HideFromTaskbarWhenInNotificationArea,
             LoopTimer = options.LoopTimer,
             PauseBeforeLoopTimer = options.PauseBeforeLoopTimer,
             PopUpWhenExpired = options.PopUpWhenExpired,
@@ -487,6 +494,7 @@ public sealed class CommandLineArguments
             ShowTimeElapsed = defaultOptions.ShowTimeElapsed,
             ShowTriggerTime = defaultOptions.ShowTriggerTime,
             ShowInNotificationArea = false,
+            HideFromTaskbarWhenInNotificationArea = false,
             LoopTimer = defaultOptions.LoopTimer,
             PauseBeforeLoopTimer = defaultOptions.PauseBeforeLoopTimer,
             PopUpWhenExpired = defaultOptions.PopUpWhenExpired,
@@ -711,6 +719,20 @@ public sealed class CommandLineArguments
 
                     argumentsBasedOnMostRecentOptions.ShowInNotificationArea = showInNotificationArea;
                     argumentsBasedOnFactoryDefaults.ShowInNotificationArea = showInNotificationArea;
+                    break;
+
+                case "--hide-from-taskbar-when-in-notification-area":
+                case "-hf":
+                case "/hf":
+                    ThrowIfDuplicateSwitch(specifiedSwitches, "--hide-from-taskbar-when-in-notification-area");
+
+                    bool hideFromTaskbarWhenInNotificationArea = GetBoolValue(
+                        arg,
+                        remainingArgs,
+                        argumentsBasedOnMostRecentOptions.HideFromTaskbarWhenInNotificationArea);
+
+                    argumentsBasedOnMostRecentOptions.HideFromTaskbarWhenInNotificationArea = hideFromTaskbarWhenInNotificationArea;
+                    argumentsBasedOnFactoryDefaults.HideFromTaskbarWhenInNotificationArea = hideFromTaskbarWhenInNotificationArea;
                     break;
 
                 case "--loop-timer":

--- a/Hourglass/Properties/Resources.Designer.cs
+++ b/Hourglass/Properties/Resources.Designer.cs
@@ -656,6 +656,15 @@ namespace Hourglass.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Hide from taskbar if shown in notification area.
+        /// </summary>
+        public static string ContextMenuHideFromTaskbarWhenInNotificationAreaMenuItem {
+            get {
+                return ResourceManager.GetString("ContextMenuHideFromTaskbarWhenInNotificationAreaMenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to S_how progress in taskbar.
         /// </summary>
         public static string ContextMenuShowProgressInTaskbarMenuItem {

--- a/Hourglass/Properties/Resources.resx
+++ b/Hourglass/Properties/Resources.resx
@@ -862,6 +862,10 @@ $</value>
     <value>S_how in notification area</value>
     <comment>The text for the show in notification area menu item, where the character following the optional underscore (_) is the access key</comment>
   </data>
+  <data name="ContextMenuHideFromTaskbarWhenInNotificationAreaMenuItem" xml:space="preserve">
+    <value>_Hide from taskbar if shown in notification area</value>
+    <comment>The text for the hide from taskbar if shown in notification area menu item, where the character following the optional underscore (_) is the access key</comment>
+  </data>
   <data name="ContextMenuSoundMenuItem" xml:space="preserve">
     <value>_Sound</value>
     <comment>The text for the sound menu item, where the character following the optional underscore (_) is the access key</comment>

--- a/Hourglass/Properties/Settings.Designer.cs
+++ b/Hourglass/Properties/Settings.Designer.cs
@@ -60,6 +60,18 @@ namespace Hourglass.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HideFromTaskbarWhenInNotificationArea {
+            get {
+                return ((bool)(this["HideFromTaskbarWhenInNotificationArea"]));
+            }
+            set {
+                this["HideFromTaskbarWhenInNotificationArea"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         public global::Hourglass.Serialization.TimerInfoList TimerInfos {
             get {
                 return ((global::Hourglass.Serialization.TimerInfoList)(this["TimerInfos"]));

--- a/Hourglass/Properties/Settings.settings
+++ b/Hourglass/Properties/Settings.settings
@@ -11,6 +11,9 @@
     <Setting Name="ShowInNotificationArea" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="HideFromTaskbarWhenInNotificationArea" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="TimerInfos" Type="Hourglass.Serialization.TimerInfoList" Scope="User">
       <Value Profile="(Default)" />
     </Setting>

--- a/Hourglass/Resources/Usage.txt
+++ b/Hourglass/Resources/Usage.txt
@@ -85,6 +85,14 @@ Options:
         Default value   last
         Alias           -n, /n
 
+  --hide-from-taskbar-when-in-notification-area on|off|last
+        Hides the timer window from the taskbar when it is shown in the
+        notification area.
+
+        Required        no
+        Default value   last
+        Alias           -hf, /hf
+
   --reverse-progress-bar on|off|last
         Reverses the direction of the progress bar, causing it to run backwards.
 
@@ -376,6 +384,7 @@ Options:
             --show-progress-in-taskbar    -y  on
             --do-not-keep-awake           -k  off
             --show-in-notification-area   -n  off
+            --hide-from-taskbar-when-in-notification-area -hf off
             --reverse-progress-bar        -g  off
             --activate-next               -an on
             --order-by-title              -ot off

--- a/Hourglass/Windows/ContextMenu.cs
+++ b/Hourglass/Windows/ContextMenu.cs
@@ -77,6 +77,11 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
     private MenuItem _showInNotificationAreaMenuItem = null!;
 
     /// <summary>
+    /// The "Hide from taskbar if shown in notification area" <see cref="MenuItem"/>.
+    /// </summary>
+    private MenuItem _hideFromTaskbarWhenInNotificationAreaMenuItem = null!;
+
+    /// <summary>
     /// The "Loop timer" <see cref="MenuItem"/>.
     /// </summary>
     private MenuItem _loopTimerMenuItem = null!;
@@ -381,6 +386,8 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
 
         // Show in notification area
         _showInNotificationAreaMenuItem.IsChecked = Settings.Default.ShowInNotificationArea;
+        _hideFromTaskbarWhenInNotificationAreaMenuItem.IsEnabled = Settings.Default.ShowInNotificationArea;
+        _hideFromTaskbarWhenInNotificationAreaMenuItem.IsChecked = Settings.Default.HideFromTaskbarWhenInNotificationArea;
 
         // Loop timer
         // Pause before looping
@@ -508,6 +515,7 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
 
         // Show in notification area
         Settings.Default.ShowInNotificationArea = _showInNotificationAreaMenuItem.IsChecked;
+        Settings.Default.HideFromTaskbarWhenInNotificationArea = _hideFromTaskbarWhenInNotificationAreaMenuItem.IsChecked;
 
         // Loop timer
         if (_loopTimerMenuItem.IsEnabled)
@@ -797,6 +805,14 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
             Header = Properties.Resources.ContextMenuShowInNotificationAreaMenuItem
         };
         _showInNotificationAreaMenuItem.Click += CheckableMenuItemClick;
+
+        _hideFromTaskbarWhenInNotificationAreaMenuItem = new CheckableMenuItem
+        {
+            Header = Properties.Resources.ContextMenuHideFromTaskbarWhenInNotificationAreaMenuItem
+        };
+        _hideFromTaskbarWhenInNotificationAreaMenuItem.Click += CheckableMenuItemClick;
+        _showInNotificationAreaMenuItem.Items.Add(_hideFromTaskbarWhenInNotificationAreaMenuItem);
+
         Items.Add(_showInNotificationAreaMenuItem);
 
         Items.Add(new Separator());
@@ -1817,4 +1833,3 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
             (IsCheckable, StaysOpenOnClick) = (true, true);
     }
 }
-

--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -251,7 +251,7 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
         TimerManager.Instance.Add(Timer);
 
         UpdateShowInTaskbar();
-        Settings.Default.PropertyChanged += SettingsPropertyChanged;
+        PropertyChangedEventManager.AddHandler(Settings.Default, SettingsPropertyChanged, string.Empty);
     }
 
     private void UpdateShellIntegration()
@@ -1524,7 +1524,7 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
 
     private void SettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is "ShowInNotificationArea" or "HideFromTaskbarWhenInNotificationArea")
+        if (e.PropertyName is nameof(Settings.Default.ShowInNotificationArea) or nameof(Settings.Default.HideFromTaskbarWhenInNotificationArea))
         {
             UpdateShowInTaskbar();
             UpdateBoundControls();
@@ -2215,7 +2215,7 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
 
             PropertyChangedEventManager.RemoveHandler(_theme, ThemePropertyChanged, string.Empty);
             PropertyChangedEventManager.RemoveHandler(UpdateManager.Instance, UpdateManagerPropertyChanged, string.Empty);
-            Settings.Default.PropertyChanged -= SettingsPropertyChanged;
+            PropertyChangedEventManager.RemoveHandler(Settings.Default, SettingsPropertyChanged, string.Empty);
 
             KeepAwakeManager.Instance.StopKeepAwakeFor(ID);
             AppManager.Instance.Persist();

--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -248,10 +248,10 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
         _menu.Bind(this);
         _scaler.Bind(this);
 
-        Settings.Default.PropertyChanged += SettingsPropertyChanged;
-        UpdateShowInTaskbar();
-
         TimerManager.Instance.Add(Timer);
+
+        UpdateShowInTaskbar();
+        Settings.Default.PropertyChanged += SettingsPropertyChanged;
     }
 
     private void UpdateShellIntegration()
@@ -1524,7 +1524,7 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
 
     private void SettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(Settings.ShowInNotificationArea) or nameof(Settings.HideFromTaskbarWhenInNotificationArea))
+        if (e.PropertyName is "ShowInNotificationArea" or "HideFromTaskbarWhenInNotificationArea")
         {
             UpdateShowInTaskbar();
             UpdateBoundControls();

--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -248,6 +248,9 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
         _menu.Bind(this);
         _scaler.Bind(this);
 
+        Settings.Default.PropertyChanged += SettingsPropertyChanged;
+        UpdateShowInTaskbar();
+
         TimerManager.Instance.Add(Timer);
     }
 
@@ -1291,7 +1294,7 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
     /// </summary>
     private void UpdateTaskbarProgress()
     {
-        if (!Options.ShowProgressInTaskbar)
+        if (!Options.ShowProgressInTaskbar || !ShowInTaskbar)
         {
             TaskbarItemInfo.ProgressState = TaskbarItemProgressState.None;
             return;
@@ -1518,6 +1521,19 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
     {
         UpdateBoundControls();
     }
+
+    private void SettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(Settings.ShowInNotificationArea) or nameof(Settings.HideFromTaskbarWhenInNotificationArea))
+        {
+            UpdateShowInTaskbar();
+            UpdateBoundControls();
+            UpdateShellIntegration();
+        }
+    }
+
+    private void UpdateShowInTaskbar() =>
+        ShowInTaskbar = !(Settings.Default.ShowInNotificationArea && Settings.Default.HideFromTaskbarWhenInNotificationArea);
 
     private void UpdateTimeToolTip()
     {
@@ -2199,6 +2215,7 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
 
             PropertyChangedEventManager.RemoveHandler(_theme, ThemePropertyChanged, string.Empty);
             PropertyChangedEventManager.RemoveHandler(UpdateManager.Instance, UpdateManagerPropertyChanged, string.Empty);
+            Settings.Default.PropertyChanged -= SettingsPropertyChanged;
 
             KeepAwakeManager.Instance.StopKeepAwakeFor(ID);
             AppManager.Instance.Persist();


### PR DESCRIPTION
This pull request adds a new feature allowing users to hide the timer window from the taskbar when it is shown in the notification area. The implementation includes a new setting, command-line option, and context menu item, as well as the necessary logic to update the window's visibility in the taskbar based on user preferences.

**New feature: Hide timer from taskbar when in notification area**
- Added a new user setting `HideFromTaskbarWhenInNotificationArea` to application settings and configuration files. [[1]](diffhunk://#diff-69eff428d3ecc54506bcd941d3909af750feceb11e658a7152468e2c18a3a1c2R19-R21) [[2]](diffhunk://#diff-e7c0d628ebf715f157828023453d45777c1dfa5cbc79a065cf8d99f25d433ea9R14-R16) [[3]](diffhunk://#diff-0e01f6b9971ae8a8391de4a9e753926c66ad6e35a8897946272e942f7baafd88R61-R72)
- Implemented a new command-line option `--hide-from-taskbar-when-in-notification-area` (aliases: `-hf`, `/hf`) to control this behavior, including parsing, usage documentation, and default handling. [[1]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR104-R109) [[2]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR449) [[3]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR497) [[4]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR724-R737) [[5]](diffhunk://#diff-41eebe0aa97a0938c4958d1d61c820254ab582a38851bd789ecdede28ecce931R88-R95) [[6]](diffhunk://#diff-41eebe0aa97a0938c4958d1d61c820254ab582a38851bd789ecdede28ecce931R387)
- Updated the context menu with a new checkable item to toggle hiding the timer from the taskbar when shown in the notification area, including resource strings and UI logic. [[1]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R79-R83) [[2]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R389-R390) [[3]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R518) [[4]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R808-R815) [[5]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855L1820) [[6]](diffhunk://#diff-aadaebccd4bdafb546566b49f9fd1386c72129f7a661be3afa24fd7c872e1449R865-R868)
- Modified `TimerWindow` logic to update the `ShowInTaskbar` property and related UI when the new setting changes, and ensured event handlers are properly managed. [[1]](diffhunk://#diff-7d36488af37617bee7ee2f6b07c9c1d07046d0c8f6298dc63770bdae151f2432R252-R254) [[2]](diffhunk://#diff-7d36488af37617bee7ee2f6b07c9c1d07046d0c8f6298dc63770bdae151f2432L1294-R1297) [[3]](diffhunk://#diff-7d36488af37617bee7ee2f6b07c9c1d07046d0c8f6298dc63770bdae151f2432R1525-R1537) [[4]](diffhunk://#diff-7d36488af37617bee7ee2f6b07c9c1d07046d0c8f6298dc63770bdae151f2432R2218)
- Updated documentation in `FAQ.md` to describe the new feature and its command-line usage.

These changes enhance user control over the application's window visibility and provide both UI and command-line access to the new behavior.

---

## Command-line support
- Added `HideFromTaskbarWhenInNotificationArea` property to `CommandLineArguments`, following the existing `ShowInNotificationArea` pattern (most-recent-options and factory-defaults resolution).
- Added `--hide-from-taskbar-when-in-notification-area` switch (aliases `-hf`, `/hf`) with `on|off|last` semantics.
- Wired the parsed value into `AppEntry.SetGlobalSettingsFromArguments` to update `Settings.Default.HideFromTaskbarWhenInNotificationArea`.

## Documentation
- Documented the new switch in `Usage.txt`, including its entry in the factory-defaults list.
- Added a mention of the setting and its command-line equivalent in `FAQ.md`, alongside the existing notification-area minimizing instructions.

```shell
hourglass -n on -hf on 5
```
starts a 5-minute timer that shows its notification-area icon and hides the timer window from the taskbar while minimized.