### PR TITLE
feat: add "Hide window title bar" option independent of window title content

### DIFF
--- a/Hourglass/CommandLineArguments.cs
+++ b/Hourglass/CommandLineArguments.cs
@@ -199,6 +199,11 @@ public sealed class CommandLineArguments
     public WindowTitleMode WindowTitleMode { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether the timer window title bar should be hidden.
+    /// </summary>
+    public bool HideWindowTitleBar { get; private set; }
+
+    /// <summary>
     /// Gets a value that indicates whether the timer window is restored, minimized, or maximized.
     /// </summary>
     public WindowState WindowState { get; private set; }
@@ -400,6 +405,7 @@ public sealed class CommandLineArguments
             Sound = Sound,
             LoopSound = LoopSound,
             WindowTitleMode = WindowTitleMode,
+            HideWindowTitleBar = HideWindowTitleBar,
             WindowSize = GetWindowSize(),
             LockInterface = LockInterface
         };
@@ -455,6 +461,7 @@ public sealed class CommandLineArguments
             ActivateNextWindow = Settings.Default.ActivateNextWindow,
             OrderByTitleFirst = Settings.Default.OrderByTitleFirst,
             WindowTitleMode = options.WindowTitleMode,
+            HideWindowTitleBar = options.HideWindowTitleBar,
             WindowState = windowSize.WindowState != WindowState.Minimized ? windowSize.WindowState : windowSize.RestoreWindowState,
             RestoreWindowState = windowSize.RestoreWindowState,
             WindowBounds = windowSize.RestoreBounds,
@@ -502,6 +509,7 @@ public sealed class CommandLineArguments
             ActivateNextWindow = true,
             OrderByTitleFirst = false,
             WindowTitleMode = WindowTitleMode.ApplicationName,
+            HideWindowTitleBar = false,
             WindowState = defaultOptions.WindowSize?.WindowState ?? WindowState.Normal,
             RestoreWindowState = defaultOptions.WindowSize?.RestoreWindowState ?? WindowState.Normal,
             WindowBounds = defaultWindowBoundsWithLocation,
@@ -933,6 +941,20 @@ public sealed class CommandLineArguments
 
                     argumentsBasedOnMostRecentOptions.WindowTitleMode = windowTitleMode;
                     argumentsBasedOnFactoryDefaults.WindowTitleMode = windowTitleMode;
+                    break;
+
+                case "--hide-window-title-bar":
+                case "-hb":
+                case "/hb":
+                    ThrowIfDuplicateSwitch(specifiedSwitches, "--hide-window-title-bar");
+
+                    bool hideWindowTitleBar = GetBoolValue(
+                        arg,
+                        remainingArgs,
+                        argumentsBasedOnMostRecentOptions.HideWindowTitleBar);
+
+                    argumentsBasedOnMostRecentOptions.HideWindowTitleBar = hideWindowTitleBar;
+                    argumentsBasedOnFactoryDefaults.HideWindowTitleBar = hideWindowTitleBar;
                     break;
 
                 case "--window-state":

--- a/Hourglass/Properties/Resources.Designer.cs
+++ b/Hourglass/Properties/Resources.Designer.cs
@@ -773,6 +773,15 @@ namespace Hourglass.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hide window title _bar.
+        /// </summary>
+        public static string ContextMenuHideWindowTitleBarMenuItem {
+            get {
+                return ResourceManager.GetString("ContextMenuHideWindowTitleBarMenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to en-US.
         /// </summary>
         public static string CultureName {

--- a/Hourglass/Properties/Resources.resx
+++ b/Hourglass/Properties/Resources.resx
@@ -1342,6 +1342,10 @@ $</value>
     <value>Win_dow title</value>
     <comment>The text for the window title menu item, where the character following the optional underscore (_) is the access key</comment>
   </data>
+  <data name="ContextMenuHideWindowTitleBarMenuItem" xml:space="preserve">
+    <value>Hide window title _bar</value>
+    <comment>The text for the hide window title bar menu item, where the character following the optional underscore (_) is the access key</comment>
+  </data>
   <data name="TimerWindowCouldNotLaunchWebBrowserErrorMessage" xml:space="preserve">
     <value>To update Hourglass, visit {0} in your web browser.</value>
     <comment>The message in the error dialog shown when the web browser could not be launched to open the download page for the latest version of the app</comment>

--- a/Hourglass/Resources/Usage.txt
+++ b/Hourglass/Resources/Usage.txt
@@ -315,6 +315,14 @@ Options:
         Default value   last
         Alias           -i, /i
 
+  --hide-window-title-bar on|off|last
+        Hides the timer window title bar, while still using the window title
+        for the taskbar.
+
+        Required        no
+        Default value   last
+        Alias           -hb, /hb
+
   --window-state normal|maximized|minimized|last
         Sets the state of the timer window.
 
@@ -397,6 +405,7 @@ Options:
             --save-timer-on-closing       -sc on
             --prefer-24h-time             -j  off
             --window-title                -i  app
+            --hide-window-title-bar       -hb off
             --window-state                -w  normal
             --window-bounds               -b  auto,auto,355,160
             --lock-interface              -z  off

--- a/Hourglass/Serialization/TimerOptionsInfo.cs
+++ b/Hourglass/Serialization/TimerOptionsInfo.cs
@@ -118,6 +118,11 @@ public sealed class TimerOptionsInfo
     public WindowTitleMode WindowTitleMode { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the timer window title bar should be hidden.
+    /// </summary>
+    public bool HideWindowTitleBar { get; set; }
+
+    /// <summary>
     /// Gets or sets the size, position, and state of the timer window.
     /// </summary>
     public WindowSizeInfo WindowSize { get; set; } = null!;

--- a/Hourglass/Timing/TimerOptions.cs
+++ b/Hourglass/Timing/TimerOptions.cs
@@ -95,6 +95,7 @@ public sealed class TimerOptions : INotifyPropertyChanged
         Sound = Sound.DefaultSound;
         LoopSound = false;
         WindowTitleMode = WindowTitleMode.ApplicationName;
+        HideWindowTitleBar = false;
         WindowSize = new(
             new(double.PositiveInfinity, double.PositiveInfinity, InterfaceScaler.BaseWindowWidth, InterfaceScaler.BaseWindowHeight),
             WindowState.Normal,
@@ -516,6 +517,25 @@ public sealed class TimerOptions : INotifyPropertyChanged
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the timer window title bar should be hidden.
+    /// </summary>
+    public bool HideWindowTitleBar
+    {
+        get;
+
+        set
+        {
+            if (field == value)
+            {
+                return;
+            }
+
+            field = value;
+            PropertyChanged.Notify(this);
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the size, position, and state of the timer window.
     /// </summary>
     public WindowSize? WindowSize
@@ -608,11 +628,13 @@ public sealed class TimerOptions : INotifyPropertyChanged
         Sound = options.Sound;
         LoopSound = options.LoopSound;
         WindowTitleMode = options.WindowTitleMode;
+        HideWindowTitleBar = options.HideWindowTitleBar;
         WindowSize = WindowSize.FromWindowSize(options.WindowSize);
         LockInterface = options.LockInterface;
 
         PropertyChanged.Notify(this,
             nameof(WindowTitleMode),
+            nameof(HideWindowTitleBar),
             nameof(WindowSize),
             nameof(Title),
             nameof(AlwaysOnTop),
@@ -667,11 +689,13 @@ public sealed class TimerOptions : INotifyPropertyChanged
         Sound = Sound.FromIdentifier(info.SoundIdentifier);
         LoopSound = info.LoopSound;
         WindowTitleMode = info.WindowTitleMode;
+        HideWindowTitleBar = info.HideWindowTitleBar;
         WindowSize = WindowSize.FromWindowSizeInfo(info.WindowSize);
         LockInterface = info.LockInterface;
 
         PropertyChanged.Notify(this,
             nameof(WindowTitleMode),
+            nameof(HideWindowTitleBar),
             nameof(WindowSize),
             nameof(Title),
             nameof(AlwaysOnTop),
@@ -722,6 +746,7 @@ public sealed class TimerOptions : INotifyPropertyChanged
             SoundIdentifier = Sound?.Identifier,
             LoopSound = LoopSound,
             WindowTitleMode = WindowTitleMode,
+            HideWindowTitleBar = HideWindowTitleBar,
             WindowSize = WindowSizeInfo.FromWindowSize(WindowSize)!,
             LockInterface = LockInterface
         };

--- a/Hourglass/Windows/ContextMenu.cs
+++ b/Hourglass/Windows/ContextMenu.cs
@@ -67,6 +67,11 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
     private MenuItem _promptOnExitMenuItem = null!;
 
     /// <summary>
+    /// The "Hide window title bar" <see cref="MenuItem"/>.
+    /// </summary>
+    private MenuItem _hideWindowTitleBarMenuItem = null!;
+
+    /// <summary>
     /// The "Show progress in taskbar" <see cref="MenuItem"/>.
     /// </summary>
     private MenuItem _showProgressInTaskbarMenuItem = null!;
@@ -478,6 +483,9 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
             menuItem.IsChecked = windowTitleMode == _timerWindow.Options.WindowTitleMode;
         }
 
+        // Hide window title bar
+        _hideWindowTitleBarMenuItem.IsChecked = _timerWindow.Options.HideWindowTitleBar;
+
         void UpdatePauseResumeAll()
         {
             var canPauseAll = TimerManager.CanPauseAll();
@@ -584,6 +592,9 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
         _timerWindow.Options.WindowTitleMode = selectedWindowTitleMenuItem is not null
             ? (WindowTitleMode)selectedWindowTitleMenuItem.Tag
             : WindowTitleMode.ApplicationName;
+
+        // Hide window title bar
+        _timerWindow.Options.HideWindowTitleBar = _hideWindowTitleBarMenuItem.IsChecked;
     }
 
     /// <summary>
@@ -772,6 +783,14 @@ public sealed class ContextMenu : System.Windows.Controls.ContextMenu
         _selectableWindowTitleMenuItems.Add(timerTitlePlusTimeElapsedWindowTitleMenuItem);
 
         Items.Add(windowTitleMenuItem);
+
+        // Hide window title bar
+        _hideWindowTitleBarMenuItem = new CheckableMenuItem
+        {
+            Header = Properties.Resources.ContextMenuHideWindowTitleBarMenuItem
+        };
+        _hideWindowTitleBarMenuItem.Click += CheckableMenuItemClick;
+        Items.Add(_hideWindowTitleBarMenuItem);
 
         Items.Add(new Separator());
 

--- a/Hourglass/Windows/TimerWindow.xaml
+++ b/Hourglass/Windows/TimerWindow.xaml
@@ -21,16 +21,7 @@
         <Style TargetType="{x:Type Window}">
             <Style.Triggers>
                 <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
-                <DataTrigger Binding="{Binding Options.WindowTitleMode, RelativeSource={RelativeSource Self}, Mode=OneWay}" Value="None">
-                    <Setter Property="WindowStyle" Value="None"/>
-                    <Setter Property="WindowChrome.WindowChrome">
-                        <Setter.Value>
-                            <WindowChrome CaptionHeight="0" UseAeroCaptionButtons="False"/>
-                        </Setter.Value>
-                    </Setter>
-                </DataTrigger>
-                <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
-                <DataTrigger Binding="{Binding Options.HideWindowTitleBar, RelativeSource={RelativeSource Self}, Mode=OneWay}" Value="True">
+                <DataTrigger Binding="{Binding IsWindowTitleBarHidden, RelativeSource={RelativeSource Self}, Mode=OneWay}" Value="True">
                     <Setter Property="WindowStyle" Value="None"/>
                     <Setter Property="WindowChrome.WindowChrome">
                         <Setter.Value>

--- a/Hourglass/Windows/TimerWindow.xaml
+++ b/Hourglass/Windows/TimerWindow.xaml
@@ -30,6 +30,15 @@
                     </Setter>
                 </DataTrigger>
                 <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
+                <DataTrigger Binding="{Binding Options.HideWindowTitleBar, RelativeSource={RelativeSource Self}, Mode=OneWay}" Value="True">
+                    <Setter Property="WindowStyle" Value="None"/>
+                    <Setter Property="WindowChrome.WindowChrome">
+                        <Setter.Value>
+                            <WindowChrome CaptionHeight="0" UseAeroCaptionButtons="False"/>
+                        </Setter.Value>
+                    </Setter>
+                </DataTrigger>
+                <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
                 <DataTrigger Binding="{Binding IsFullScreen, RelativeSource={RelativeSource Self}, Mode=OneWay}" Value="True">
                     <Setter Property="WindowStyle" Value="None"/>
                 </DataTrigger>

--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -1499,8 +1499,7 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
     {
         switch (e.PropertyName)
         {
-            case nameof(Options.WindowTitleMode) when Options.WindowTitleMode != WindowTitleMode.None && !Options.HideWindowTitleBar:
-            case nameof(Options.HideWindowTitleBar) when !Options.HideWindowTitleBar && Options.WindowTitleMode != WindowTitleMode.None:
+            case nameof(Options.WindowTitleMode) or nameof(Options.HideWindowTitleBar) when Options.WindowTitleMode != WindowTitleMode.None && !Options.HideWindowTitleBar:
                 Width  = Math.Max(Width,  this.GetMinTrackWidth());
                 Height = Math.Max(Height, this.GetMinTrackHeight());
                 break;

--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -1494,7 +1494,8 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
     {
         switch (e.PropertyName)
         {
-            case nameof(Options.WindowTitleMode) when Options.WindowTitleMode != WindowTitleMode.None:
+            case nameof(Options.WindowTitleMode) when Options.WindowTitleMode != WindowTitleMode.None && !Options.HideWindowTitleBar:
+            case nameof(Options.HideWindowTitleBar) when !Options.HideWindowTitleBar && Options.WindowTitleMode != WindowTitleMode.None:
                 Width  = Math.Max(Width,  this.GetMinTrackWidth());
                 Height = Math.Max(Height, this.GetMinTrackHeight());
                 break;

--- a/Hourglass/Windows/TimerWindow.xaml.cs
+++ b/Hourglass/Windows/TimerWindow.xaml.cs
@@ -366,6 +366,11 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
     public Theme? Theme => _theme;
 
     /// <summary>
+    /// Gets a value indicating whether the window title bar should be hidden.
+    /// </summary>
+    public bool IsWindowTitleBarHidden => Options.WindowTitleMode == WindowTitleMode.None || Options.HideWindowTitleBar;
+
+    /// <summary>
     /// Gets or sets a value indicating whether the window is in full-screen mode.
     /// </summary>
     public bool IsFullScreen
@@ -1505,6 +1510,11 @@ public sealed partial class TimerWindow : INotifyPropertyChanged, IRestorableWin
                 PropertyChangedEventManager.AddHandler(_theme, ThemePropertyChanged, string.Empty);
                 SetImmersiveDarkMode();
                 break;
+        }
+
+        if (e.PropertyName is nameof(Options.WindowTitleMode) or nameof(Options.HideWindowTitleBar))
+        {
+            PropertyChanged.Notify(this, nameof(IsWindowTitleBarHidden));
         }
 
         UpdateBoundControls();

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ See [command-line usage](https://github.com/i2van/hourglass/blob/main/Hourglass/
 - The **Resume all** timer window context menu command resumes all the paused timers. Command-line command is [`resume`](https://github.com/search?type=code&q=repo%3Ai2van%2Fhourglass+path%3AHourglass%2FResources%2FUsage.txt+resume)
 - The **Pause after each loop** timer window context menu command pauses the loop timer when it expires. Command-line command is [`--pause-after-loop-timer`](https://github.com/search?type=code&q=repo%3Ai2van%2Fhourglass+path%3AHourglass%2FResources%2FUsage.txt+--pause-after-loop-timer), `-pl`, `/pl`
 - The **Minimize when expired** timer window context menu command minimizes the timer window when the timer expires. Command-line option is [`--minimize-when-expired`](https://github.com/search?type=code&q=repo%3Ai2van%2Fhourglass+path%3AHourglass%2FResources%2FUsage.txt+--minimize-when-expired), `-em`, `/em`
+- The **Hide window title bar** timer window context menu option hides the timer window title bar while still using the timer window title for the taskbar. The command-line option is [`--hide-window-title-bar`](https://github.com/search?type=code&q=repo%3Ai2van%2Fhourglass+path%3AHourglass%2FResources%2FUsage.txt+--hide-window-title-bar), `-hb`, `/hb`
 
 #### Other
 


### PR DESCRIPTION
This pull request adds a new feature that allows users to hide the timer window title bar via both the command line and the context menu. It introduces a `HideWindowTitleBar` option throughout the codebase, updates the UI and serialization logic to support this setting, and documents the new option in the usage and help files.

**New Feature: Hide Window Title Bar**

* Added a `HideWindowTitleBar` option to `TimerOptions`, `CommandLineArguments`, and `TimerOptionsInfo`, including support for serialization, deserialization, and property change notifications. [[1]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR201-R205) [[2]](diffhunk://#diff-b228db38aa6ec8ebc07387d3f0994875dd565e3cff2d7dffd96fc989d6259f9aR120-R124) [[3]](diffhunk://#diff-9c57eb0be18e7c1ac918810111840aa5da5c217dfae6692ea6be82e81196a92eR98) [[4]](diffhunk://#diff-9c57eb0be18e7c1ac918810111840aa5da5c217dfae6692ea6be82e81196a92eR519-R537) [[5]](diffhunk://#diff-9c57eb0be18e7c1ac918810111840aa5da5c217dfae6692ea6be82e81196a92eR631-R637) [[6]](diffhunk://#diff-9c57eb0be18e7c1ac918810111840aa5da5c217dfae6692ea6be82e81196a92eR692-R698) [[7]](diffhunk://#diff-9c57eb0be18e7c1ac918810111840aa5da5c217dfae6692ea6be82e81196a92eR749)
* Implemented command-line parsing for the new `--hide-window-title-bar` option, with support for aliases and default values. [[1]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR946-R959) [[2]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR408) [[3]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR464) [[4]](diffhunk://#diff-4b621166d0261d87dd6dc9d3228535d04c7c6d59d14085ac00f938bd18458eefR512)
* Updated the context menu to include a "Hide window title bar" item, with proper localization, state synchronization, and event handling. [[1]](diffhunk://#diff-cd68afe26384aea66592a8033ab61ced24534c7f80bd5f219a1719e6abac018cR775-R783) [[2]](diffhunk://#diff-aadaebccd4bdafb546566b49f9fd1386c72129f7a661be3afa24fd7c872e1449R1345-R1348) [[3]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R69-R73) [[4]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R486-R488) [[5]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R595-R597) [[6]](diffhunk://#diff-9a6c74d56d9df0c8be946c1746d08b41ebf50fca913f52dc4eead645eb219855R787-R794)
* Modified the window logic and XAML to use the new `IsWindowTitleBarHidden` property, ensuring the title bar is hidden when either the old or new option is set. [[1]](diffhunk://#diff-08aa0344c072f930852a50fb0b303aedf1b559b8567d46d440ee8460133cb553L24-R24) [[2]](diffhunk://#diff-7d36488af37617bee7ee2f6b07c9c1d07046d0c8f6298dc63770bdae151f2432R368-R372) [[3]](diffhunk://#diff-7d36488af37617bee7ee2f6b07c9c1d07046d0c8f6298dc63770bdae151f2432L1497-R1502) [[4]](diffhunk://#diff-7d36488af37617bee7ee2f6b07c9c1d07046d0c8f6298dc63770bdae151f2432R1514-R1518)
* Documented the new option in `README.md` and updated `Usage.txt` to reflect the new command-line flag and its description. [[1]](diffhunk://#diff-41eebe0aa97a0938c4958d1d61c820254ab582a38851bd789ecdede28ecce931R318-R325) [[2]](diffhunk://#diff-41eebe0aa97a0938c4958d1d61c820254ab582a38851bd789ecdede28ecce931R408) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165)

---

Setting "Window title" to "None" was the only way to hide the timer window's title bar, but that also removed the title from the taskbar. There was no way to show a meaningful title in the taskbar while hiding the title bar on the window itself.

## Option plumbing
- Added `HideWindowTitleBar` bool to `TimerOptions`, wired into construction, copy/clone, and `TimerOptionsInfo` serialization.

## Window behavior
- Added computed `IsWindowTitleBarHidden` on `TimerWindow` (`WindowTitleMode == None || HideWindowTitleBar`), notified whenever either source option changes.
- `TimerWindow.xaml` now drives the title bar visibility from this single property instead of duplicating the `WindowStyle`/`WindowChrome` setters per condition.

## UI / CLI
- New "Hide window title bar" checkable item in the timer window context menu, alongside the existing "Window title" submenu.
- New `--hide-window-title-bar` command-line switch (aliases `-hb`, `/hb`), documented in `Usage.txt` and `README.md`.

Now a "Timer title" (or any other) window title mode can be combined with "Hide window title bar" to show a meaningful title in the taskbar without the title bar cluttering the window itself.